### PR TITLE
Use internal user IDs from statbot

### DIFF
--- a/db.py
+++ b/db.py
@@ -17,7 +17,8 @@ class Channels(Base):
 
 class Users(Base):
 	__tablename__ = 'users'
-	user_id = Column(Integer, primary_key=True)
+	int_user_id = Column(Integer, primary_key=True)
+	real_user_id = Column(Integer)
 	name = Column(String)
 
 class Months(Base):
@@ -28,7 +29,7 @@ class Months(Base):
 class Messages(Base):
 	__tablename__ = 'messages'
 	channel_id = Column(Integer, primary_key=True)
-	user_id = Column(Integer, primary_key=True)
+	int_user_id = Column(Integer, primary_key=True)
 	hour = Column(Integer, primary_key=True)
 	count = Column(Integer)
 
@@ -38,26 +39,26 @@ def top_user_ids():
 	session = Session()
 
 	query = session.query(Messages) \
-			.with_entities(Messages.user_id) \
+			.with_entities(Messages.int_user_id) \
 			.filter(Messages.hour > time.time() - 30 * 24 * 60 * 60) \
-			.group_by(Messages.user_id).order_by(func.sum(Messages.count).desc())
+			.group_by(Messages.int_user_id).order_by(func.sum(Messages.count).desc())
 	query = query.limit(TOP_USER_COUNT)
 
 	user_ids = set()
 	for row in query:
-		user_ids.add(str(row.user_id))
+		user_ids.add(str(row.int_user_id))
 	return user_ids
 
 def top_usernames():
 	session = Session()
 	query = session.query(Messages) \
-			.with_entities(Messages.user_id, Users.name) \
-			.outerjoin(Users, Messages.user_id == Users.user_id) \
+			.with_entities(Messages.int_user_id, Users.name) \
+			.outerjoin(Users, Messages.int_user_id == Users.int_user_id) \
 			.filter(Messages.hour > time.time() - 30 * 24 * 60 * 60) \
-			.group_by(Messages.user_id).order_by(func.sum(Messages.count).desc())
+			.group_by(Messages.int_user_id).order_by(func.sum(Messages.count).desc())
 	query = query.limit(TOP_USER_COUNT)
 
 	usernames = []
 	for row in query:
-		usernames.append(row.name or str(row.user_id))
+		usernames.append(row.name or str(row.int_user_id))
 	return usernames

--- a/ddd.py
+++ b/ddd.py
@@ -32,7 +32,7 @@ def channel_user_month_list(request):
 
 	users = []
 	for row in session.query(Users).order_by(Users.name):
-		users.append({'id': str(row.user_id), 'name': row.name})
+		users.append({'id': str(row.int_user_id), 'name': row.name})
 
 	months = []
 	for row in session.query(Months).order_by(Months.month):
@@ -72,16 +72,16 @@ def by_user(request):
 	total = _filter(query, request.query).scalar()
 
 	query = session.query(Messages) \
-			.with_entities(Messages.user_id, Users.name, func.sum(Messages.count).label('count')) \
-			.outerjoin(Users, Messages.user_id == Users.user_id) \
-			.group_by(Messages.user_id).order_by(func.sum(Messages.count).desc())
+			.with_entities(Messages.int_user_id, Users.name, func.sum(Messages.count).label('count')) \
+			.outerjoin(Users, Messages.int_user_id == Users.int_user_id) \
+			.group_by(Messages.int_user_id).order_by(func.sum(Messages.count).desc())
 	query = _filter(query, request.query)
 	query = query.limit(50)
 
 	data = []
 	for row in query:
 		data.append({
-			'name': row.name or str(row.user_id),
+			'name': row.name or str(row.real_user_id),
 			'count': row.count,
 			'percentage': float('%.2f' % (row.count / total * 100)),
 		})
@@ -110,8 +110,8 @@ def by_channel(request):
 def _filter(query, qs):
 	if 'channel_id' in qs:
 		query = query.filter(Messages.channel_id == int(qs['channel_id']))
-	if 'user_id' in qs:
-		query = query.filter(Messages.user_id == int(qs['user_id']))
+	if 'int_user_id' in qs:
+		query = query.filter(Messages.int_user_id == int(qs['int_user_id']))
 	if 'month' in qs:
 		start = datetime.datetime.strptime(qs['month'], '%Y-%m').replace(tzinfo=datetime.timezone.utc)
 		end = (start + datetime.timedelta(days=31)).replace(day=1)

--- a/dump_csvs.sql
+++ b/dump_csvs.sql
@@ -1,3 +1,3 @@
 \COPY (SELECT channel_id, name FROM channels WHERE guild_id = 181866934353133570) TO 'raw/channels.csv' DELIMITER ',' CSV HEADER;
-\COPY (SELECT real_user_id, int_user_id, name FROM users) TO 'raw/users.csv' DELIMITER ',' CSV HEADER;
+\COPY (SELECT int_user_id, real_user_id, name FROM users) TO 'raw/users.csv' DELIMITER ',' CSV HEADER;
 \COPY (SELECT message_id, channel_id, int_user_id, content FROM messages WHERE guild_id = 181866934353133570) TO 'raw/messages.csv' DELIMITER ',' CSV HEADER;

--- a/dump_csvs.sql
+++ b/dump_csvs.sql
@@ -1,3 +1,3 @@
 \COPY (SELECT channel_id, name FROM channels WHERE guild_id = 181866934353133570) TO 'raw/channels.csv' DELIMITER ',' CSV HEADER;
-\COPY (SELECT user_id, name FROM users) TO 'raw/users.csv' DELIMITER ',' CSV HEADER;
-\COPY (SELECT message_id, channel_id, user_id, content FROM messages WHERE guild_id = 181866934353133570) TO 'raw/messages.csv' DELIMITER ',' CSV HEADER;
+\COPY (SELECT real_user_id, int_user_id, name FROM users) TO 'raw/users.csv' DELIMITER ',' CSV HEADER;
+\COPY (SELECT message_id, channel_id, int_user_id, content FROM messages WHERE guild_id = 181866934353133570) TO 'raw/messages.csv' DELIMITER ',' CSV HEADER;

--- a/prepare_db.py
+++ b/prepare_db.py
@@ -18,17 +18,17 @@ def main():
 	with conn:
 		conn.executemany('INSERT INTO channels (channel_id, name) VALUES(?, ?)',
 				iter_channels('raw/channels.csv'))
-		conn.executemany('INSERT INTO users (user_id, name) VALUES(?, ?)',
+		conn.executemany('INSERT INTO users (int_user_id, real_user_id, name) VALUES(?, ?, ?)',
 				iter_users('raw/users.csv'))
 
 	counts = defaultdict(lambda: defaultdict(lambda: defaultdict(int))) # [channel][user][hour]
 	months = set()
 	for row in iter_rows('raw/messages.csv.lzma', verbose):
 		channel_id = int(row['channel_id'])
-		user_id = int(row['user_id'])
+		int_user_id = int(row['int_user_id'])
 		dt = snowflake_dt(int(row['message_id']))
 		hour = dt.replace(minute=0, second=0, tzinfo=datetime.timezone.utc).timestamp()
-		counts[channel_id][user_id][hour] += 1
+		counts[channel_id][int_user_id][hour] += 1
 
 		month = dt.date().replace(day=1)
 		months.add(month)
@@ -39,7 +39,7 @@ def main():
 
 	with conn:
 		conn.executemany('INSERT INTO months (month) VALUES(?)', month_rows)
-		conn.executemany('INSERT INTO messages (channel_id, user_id, hour, count) VALUES(?, ?, ?, ?)',
+		conn.executemany('INSERT INTO messages (channel_id, int_user_id, hour, count) VALUES(?, ?, ?, ?)',
 				iter_counts(counts))
 
 def prepare_db(verbose):
@@ -57,7 +57,8 @@ def prepare_db(verbose):
 		''')
 		conn.execute('''
 			CREATE TABLE users (
-				user_id INTEGER PRIMARY KEY,
+				int_user_id INTEGER PRIMARY KEY,
+				real_user_id INTEGER,
 				name TEXT
 			)
 		''')
@@ -69,14 +70,14 @@ def prepare_db(verbose):
 		conn.execute('''
 			CREATE TABLE messages (
 				channel_id INTEGER,
-				user_id INTEGER,
+				int_user_id INTEGER,
 				hour INTEGER,
 				count INTEGER
 			)
 		''')
 		conn.execute('''
 			CREATE UNIQUE INDEX channel_user_hour ON messages
-			(channel_id, user_id, hour)
+			(channel_id, int_user_id, hour)
 		''')
 
 	return conn
@@ -92,8 +93,8 @@ def iter_users(users_path):
 	with open(users_path, 'r') as f:
 		reader = csv.DictReader(f)
 		for row in reader:
-			user_id = int(row['user_id'])
-			yield (user_id, row['name'])
+			int_user_id = int(row['int_user_id'])
+			yield (int_user_id, row['name'])
 
 def iter_rows(messages_xz_path, verbose):
 	with lzma.open(messages_xz_path, 'rt', encoding='utf-8') as f:
@@ -105,9 +106,9 @@ def iter_rows(messages_xz_path, verbose):
 
 def iter_counts(counts):
 	for channel_id, user_counts in counts.items():
-		for user_id, hour_counts in user_counts.items():
+		for int_user_id, hour_counts in user_counts.items():
 			for hour, count in hour_counts.items():
-				yield (channel_id, user_id, hour, count)
+				yield (channel_id, int_user_id, hour, count)
 
 DISCORD_EPOCH = 1420070400000
 def snowflake_dt(snowflake):

--- a/static/ddd.js
+++ b/static/ddd.js
@@ -21,7 +21,7 @@ window.addEvent('domready', function() {
 		if (channelSelect.value)
 			qs['channel_id'] = channelSelect.value;
 		if (userSelect.value)
-			qs['user_id'] = userSelect.value;
+			qs['int_user_id'] = userSelect.value;
 		if (monthSelect.value)
 			qs['month'] = monthSelect.value;
 		if (!initial)
@@ -74,7 +74,7 @@ window.addEvent('domready', function() {
 			params[key] = decodeURIComponent(val);
 		});
 		channelSelect.select(params['channel_id'] || null);
-		userSelect.select(params['user_id'] || null);
+		userSelect.select(params['int_user_id'] || null);
 		monthSelect.select(params['month'] || null);
 
 		channelSelect.addEvent('moodropdown-select', () => {query(false);});


### PR DESCRIPTION
There was a change in the statbot schema to now use a layer of indirection between users and user identification to make GDPR compliance easier. `int_user_id` is a unique int64 that identifies a user, while `real_user_id`, if it exists, is the actual discord ID.

This PR probably has a lot of problems, but at least some of the grunt work is done here.